### PR TITLE
Fix dump on entities

### DIFF
--- a/lib/ecwid_api/entity.rb
+++ b/lib/ecwid_api/entity.rb
@@ -1,8 +1,8 @@
 module EcwidApi
   class Entity
     # Private: Gets the Hash of data
-    attr_reader :data
-    protected   :data
+    attr_reader :data, :new_data
+    protected   :data, :new_data
 
     attr_reader :client
     private     :client
@@ -172,6 +172,18 @@ module EcwidApi
 
     def to_json(*args)
       data.to_json(*args)
+    end
+
+    def marshal_dump
+      [@data, @new_data]
+    end
+
+    def marshal_load(array)
+      @data, @new_data = *array
+    end
+
+    def ==(other)
+      data == other.data && new_data == other.new_data
     end
   end
 end

--- a/spec/entity_spec.rb
+++ b/spec/entity_spec.rb
@@ -42,7 +42,6 @@ describe EcwidApi::Entity do
     end
   end
 
-
   describe "#[]" do
     it "gets data with a symbol key" do
       subject[:id].should == 123
@@ -61,12 +60,21 @@ describe EcwidApi::Entity do
     end
   end
 
+  describe "#==" do
+    context "with and without a client" do
+      let(:other) { EntitySubject.new(data, client: client) }
+
+      it "returns true" do
+        expect(subject).to eq(other)
+      end
+    end
+  end
+
   describe "overrides" do
     its(:override) { should == "UPCASE ME" }
   end
 
   describe "accessors" do
-
     describe "::ecwid_reader" do
       it "makes data accessible with a snake cased method" do
         subject.parent_id.should == 456
@@ -102,6 +110,25 @@ describe EcwidApi::Entity do
 
       it "doesn't have an access method" do
         expect { subject.hidden }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
+  describe "marshaling" do
+    context "with a client" do
+      subject { EntitySubject.new(data, client: client) }
+
+      describe "dump" do
+        it "does not raise" do
+          expect { Marshal.dump(subject) }.not_to raise_error
+        end
+      end
+
+      describe "load" do
+        it "converts a dumped object" do
+          source = Marshal.dump(subject)
+          expect(Marshal.load(source)).to eq(subject)
+        end
       end
     end
   end


### PR DESCRIPTION
## Problems

- Entities with a `client` attribute cannot be marshalled.
- The above breaks Rails caching.

## Solution

- Serialize `data` and `new_data` attributes only.

I found this useful to keep around Ecwid entities in Redis.